### PR TITLE
Fixed error TS4023 which would occur during use

### DIFF
--- a/src/styled-components-ts.ts
+++ b/src/styled-components-ts.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import styledComponents, { ThemedStyledFunction } from 'styled-components';
+import styledComponents, { ThemedStyledFunction, StyledComponentClass } from 'styled-components';
 
 const styledComponentWithProps =
   <TProps, U extends HTMLElement = HTMLElement>
@@ -10,3 +10,4 @@ const styledComponentWithProps =
   };
 
 export default styledComponentWithProps;
+export { StyledComponentClass };


### PR DESCRIPTION
**Deps**:  "typescript": "^2.7.1"

**Example**:
```typescript
import * as React from "react";
import styled from "styled-components";
import themed from "styled-components-ts";

export interface IProps{}

const Foo = themed<IProps>(styled.div)`
  /* some styles */
`;

export default Foo;
```

**Error message**:
```
[ts] Exported variable 'Foo' has or is using name 'StyledComponentClass' from external module "e:/Workspace/xxxx/node_modules/styled-components-ts/node_modules/styled-components/typings/styled-components" but cannot be named.
```

After applying this PR, you can modify example code like this to avoid [TS4023].(https://github.com/Microsoft/TypeScript/issues/5711)

```typescript
import * as React from "react";
import styled from "styled-components";
import themed, { StyledComponentClass } from "styled-components-ts";

export interface IProps{}

const Foo = themed<IProps>(styled.div)`
  /* some styles */
`;

export default Foo;
```
