### PR TITLE
Update styled-components peerDependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "react": ">= 0.14.0 < 17.0.0-0",
-    "styled-components": ">= 2.0.0 < 4.0.0"
+    "styled-components": ">= 2.0.0"
   },
   "devDependencies": {
     "@types/react": "16.0.5",
@@ -28,7 +28,7 @@
     "tslint": "^5.9.1",
     "tslint-config-standard": "^7.0.0",
     "source-map-loader": "0.2.1",
-    "styled-components": "^3.2.5",
+    "styled-components": "^4.0.0",
     "typescript": "^2.8.1",
     "uglifyjs-webpack-plugin": "0.4.6",
     "webpack": "3.6.0"


### PR DESCRIPTION
This change should stop the warnings that occur when installing this package, when using styled-components v4 or above. This addresses issue #15 